### PR TITLE
Refactor developer dashboard widgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,19 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  NODE_VERSION: 22.x
+
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [18.x]  # Build on Node.js 18
-
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ env.NODE_VERSION }}
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v2.0.1
@@ -42,10 +40,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Node.js 18.x
+    - name: Setup Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
       with:
-        node-version: 18.x
+        node-version: ${{ env.NODE_VERSION }}
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v2.0.1
@@ -71,10 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2.0.1

--- a/addon/components/widget/api-traffic.hbs
+++ b/addon/components/widget/api-traffic.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersChart @endpoint="api-traffic" @title={{t "developers.component.widget.dashboard.api-traffic.title"}} @subtitle={{t "developers.component.widget.dashboard.api-traffic.subtitle"}} />

--- a/addon/components/widget/api-traffic.js
+++ b/addon/components/widget/api-traffic.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetApiTrafficComponent extends Component {
+    widget = 'api-traffic';
+}

--- a/addon/components/widget/developer-activity.hbs
+++ b/addon/components/widget/developer-activity.hbs
@@ -1,0 +1,30 @@
+<div class="developers-dashboard-widget flex h-full flex-col overflow-hidden rounded-md border bg-white shadow-sm dark:bg-gray-800" ...attributes>
+    <div class="developers-widget-header">
+        <div class="min-w-0">
+            <div class="developers-widget-title">{{t "developers.component.widget.dashboard.developer-activity.title"}}</div>
+            <div class="developers-widget-subtitle">{{t "developers.component.widget.dashboard.developer-activity.subtitle"}}</div>
+        </div>
+        <button type="button" class="developers-widget-icon-button" {{on "click" this.refresh}} title={{t "developers.common.reload"}}>
+            <FaIcon @icon="rotate" class={{if this.load.isRunning "animate-spin"}} />
+        </button>
+    </div>
+    <div class="developers-widget-scroll-body">
+        {{#if this.load.isRunning}}
+            <div class="developers-empty-state"><Spinner /></div>
+        {{else if this.error}}
+            <div class="developers-empty-state text-rose-500">{{this.error}}</div>
+        {{else if this.items.length}}
+            {{#each this.items as |item|}}
+                <div class="developers-activity-row">
+                    <div class="developers-activity-icon"><FaIcon @icon={{this.iconFor item.type}} /></div>
+                    <div class="min-w-0">
+                        <div class="developers-list-title">{{item.label}}</div>
+                        <div class="developers-list-subtitle">{{item.type}} / {{item.status}}</div>
+                    </div>
+                </div>
+            {{/each}}
+        {{else}}
+            <div class="developers-empty-state">{{t "developers.component.widget.dashboard.empty"}}</div>
+        {{/if}}
+    </div>
+</div>

--- a/addon/components/widget/developer-activity.js
+++ b/addon/components/widget/developer-activity.js
@@ -1,0 +1,46 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+
+export default class WidgetDeveloperActivityComponent extends Component {
+    @service fetch;
+
+    @tracked data = null;
+    @tracked error = null;
+
+    constructor() {
+        super(...arguments);
+        this.load.perform();
+    }
+
+    get items() {
+        return this.data?.items ?? [];
+    }
+
+    iconFor(type) {
+        if (type === 'webhook') {
+            return 'webhook';
+        }
+
+        if (type === 'event') {
+            return 'bolt';
+        }
+
+        return 'terminal';
+    }
+
+    @task *load() {
+        try {
+            this.data = yield this.fetch.get('metrics/dev/activity', { limit: 14 });
+            this.error = null;
+        } catch (error) {
+            this.error = error?.message ?? 'Unable to load activity';
+        }
+    }
+
+    @action refresh() {
+        this.load.perform();
+    }
+}

--- a/addon/components/widget/developers-chart.hbs
+++ b/addon/components/widget/developers-chart.hbs
@@ -1,0 +1,22 @@
+<div class="developers-dashboard-widget developers-chart-widget flex h-full flex-col rounded-md border bg-white shadow-sm dark:bg-gray-800" ...attributes>
+    <div class="developers-widget-header">
+        <div class="min-w-0">
+            <div class="developers-widget-title">{{@title}}</div>
+            <div class="developers-widget-subtitle">{{@subtitle}}</div>
+        </div>
+        <button type="button" class="developers-widget-icon-button" {{on "click" this.refresh}} title={{t "developers.common.reload"}}>
+            <FaIcon @icon="rotate" class={{if this.load.isRunning "animate-spin"}} />
+        </button>
+    </div>
+    <div class="developers-chart-body">
+        {{#if this.load.isRunning}}
+            <div class="flex h-full w-full items-center justify-center"><Spinner /></div>
+        {{else if this.error}}
+            <div class="flex h-full w-full items-center justify-center text-xs text-rose-500">{{this.error}}</div>
+        {{else}}
+            <div class="developers-chart-frame">
+                <Chart @type={{or @type "line"}} @labels={{this.labels}} @datasets={{this.datasets}} @options={{this.chartOptions}} />
+            </div>
+        {{/if}}
+    </div>
+</div>

--- a/addon/components/widget/developers-chart.js
+++ b/addon/components/widget/developers-chart.js
@@ -1,0 +1,77 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+
+const COLORS = [
+    ['#2563eb', 'rgba(37, 99, 235, 0.15)'],
+    ['#10b981', 'rgba(16, 185, 129, 0.15)'],
+    ['#ef4444', 'rgba(239, 68, 68, 0.15)'],
+    ['#f59e0b', 'rgba(245, 158, 11, 0.15)'],
+];
+
+export default class WidgetDevelopersChartComponent extends Component {
+    @service fetch;
+
+    @tracked data = null;
+    @tracked error = null;
+
+    constructor() {
+        super(...arguments);
+        this.load.perform();
+    }
+
+    get labels() {
+        return this.data?.labels ?? [];
+    }
+
+    get datasets() {
+        return (this.data?.datasets ?? []).map((dataset, index) => {
+            const color = COLORS[index % COLORS.length];
+
+            return {
+                ...dataset,
+                borderColor: color[0],
+                backgroundColor: color[1],
+                borderWidth: 2,
+                fill: true,
+                tension: 0.35,
+                pointRadius: 0,
+                pointHoverRadius: 4,
+            };
+        });
+    }
+
+    get chartOptions() {
+        return {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            plugins: {
+                legend: {
+                    display: true,
+                    position: 'top',
+                    labels: { usePointStyle: true, boxWidth: 8, boxHeight: 8 },
+                },
+            },
+            scales: {
+                x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+                y: { beginAtZero: true, grid: { color: 'rgba(148, 163, 184, 0.16)' } },
+            },
+        };
+    }
+
+    @task *load() {
+        try {
+            this.data = yield this.fetch.get(`metrics/dev/${this.args.endpoint}`, { period: this.args.period ?? '30d' });
+            this.error = null;
+        } catch (error) {
+            this.error = error?.message ?? 'Unable to load chart';
+        }
+    }
+
+    @action refresh() {
+        this.load.perform();
+    }
+}

--- a/addon/components/widget/developers-kpi-tile.hbs
+++ b/addon/components/widget/developers-kpi-tile.hbs
@@ -1,0 +1,24 @@
+<div class="developers-dashboard-widget developers-kpi-tile {{this.accentClass}} h-full rounded-md border shadow-sm overflow-hidden" ...attributes>
+    <div class="flex h-full flex-col justify-between p-3">
+        <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0">
+                <div class="developers-kpi-label truncate">{{this.title}}</div>
+                {{#if this.error}}
+                    <div class="mt-2 text-xs font-semibold text-rose-600 dark:text-rose-300 truncate">{{this.error}}</div>
+                {{else if this.load.isRunning}}
+                    <div class="mt-3"><Spinner /></div>
+                {{else}}
+                    <div class="developers-kpi-value mt-2 truncate">{{this.value}}</div>
+                {{/if}}
+            </div>
+            <button type="button" class="developers-kpi-icon flex items-center justify-center rounded-md" {{on "click" this.refresh}} title={{t "developers.common.reload"}}>
+                <FaIcon @icon={{@icon}} @prefix={{or @iconPrefix "fas"}} class={{if this.load.isRunning "animate-spin"}} />
+            </button>
+        </div>
+
+        <div class="mt-3 flex items-center justify-between gap-2 text-[11px]">
+            <span class="text-gray-500 dark:text-gray-400 truncate">{{or @footnote (t "developers.component.widget.dashboard.period")}}</span>
+            <Badge @status={{this.deltaStatus}} @text={{this.deltaText}} @hideIcon={{true}} @disableHumanize={{true}} @wrapperClass="developers-kpi-delta text-[10px] px-2 py-0.5 font-bold" />
+        </div>
+    </div>
+</div>

--- a/addon/components/widget/developers-kpi-tile.js
+++ b/addon/components/widget/developers-kpi-tile.js
@@ -1,0 +1,79 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+
+export default class WidgetDevelopersKpiTileComponent extends Component {
+    @service fetch;
+
+    @tracked data = null;
+    @tracked error = null;
+
+    constructor() {
+        super(...arguments);
+        this.load.perform();
+    }
+
+    get metric() {
+        return this.data?.metrics?.[this.args.metric] ?? {};
+    }
+
+    get title() {
+        return this.args.title ?? this.metric.label ?? 'Metric';
+    }
+
+    get value() {
+        const value = this.metric.value ?? 0;
+
+        if (this.metric.format === 'percent') {
+            return `${value}%`;
+        }
+
+        if (this.metric.format === 'duration') {
+            return `${Number(value).toLocaleString()}ms`;
+        }
+
+        return Number(value).toLocaleString();
+    }
+
+    get deltaText() {
+        const delta = this.metric.delta_percent;
+
+        if (typeof delta !== 'number') {
+            return 'Current';
+        }
+
+        return `${delta > 0 ? '+' : ''}${delta}%`;
+    }
+
+    get deltaStatus() {
+        const delta = this.metric.delta_percent;
+
+        if (typeof delta !== 'number' || delta === 0) {
+            return 'info';
+        }
+
+        const positive = delta > 0;
+        const isGood = this.metric.inverse ? !positive : positive;
+
+        return isGood ? 'success' : 'danger';
+    }
+
+    get accentClass() {
+        return `developers-kpi-accent-${this.args.accent ?? 'blue'}`;
+    }
+
+    @task *load() {
+        try {
+            this.data = yield this.fetch.get('metrics/dev/kpis', { period: this.args.period ?? '30d' });
+            this.error = null;
+        } catch (error) {
+            this.error = error?.message ?? 'Unable to load metric';
+        }
+    }
+
+    @action refresh() {
+        this.load.perform();
+    }
+}

--- a/addon/components/widget/endpoint-health.hbs
+++ b/addon/components/widget/endpoint-health.hbs
@@ -1,0 +1,30 @@
+<div class="developers-dashboard-widget flex h-full flex-col overflow-hidden rounded-md border bg-white shadow-sm dark:bg-gray-800" ...attributes>
+    <div class="developers-widget-header">
+        <div class="min-w-0">
+            <div class="developers-widget-title">{{t "developers.component.widget.dashboard.endpoint-health.title"}}</div>
+            <div class="developers-widget-subtitle">{{t "developers.component.widget.dashboard.endpoint-health.subtitle"}}</div>
+        </div>
+        <button type="button" class="developers-widget-icon-button" {{on "click" this.refresh}} title={{t "developers.common.reload"}}>
+            <FaIcon @icon="rotate" class={{if this.load.isRunning "animate-spin"}} />
+        </button>
+    </div>
+    <div class="developers-widget-scroll-body">
+        {{#if this.load.isRunning}}
+            <div class="developers-empty-state"><Spinner /></div>
+        {{else if this.error}}
+            <div class="developers-empty-state text-rose-500">{{this.error}}</div>
+        {{else if this.items.length}}
+            {{#each this.items as |item|}}
+                <div class="developers-list-row">
+                    <div class="min-w-0">
+                        <div class="developers-list-title">{{item.url}}</div>
+                        <div class="developers-list-subtitle">{{item.status}} / {{item.mode}} / {{item.deliveries}} deliveries</div>
+                    </div>
+                    <div class="developers-list-metric {{this.statusClass item}}">{{item.success_rate}}%</div>
+                </div>
+            {{/each}}
+        {{else}}
+            <div class="developers-empty-state">{{t "developers.component.widget.dashboard.empty"}}</div>
+        {{/if}}
+    </div>
+</div>

--- a/addon/components/widget/endpoint-health.js
+++ b/addon/components/widget/endpoint-health.js
@@ -1,0 +1,42 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+
+export default class WidgetEndpointHealthComponent extends Component {
+    @service fetch;
+
+    @tracked data = null;
+    @tracked error = null;
+
+    constructor() {
+        super(...arguments);
+        this.load.perform();
+    }
+
+    get items() {
+        return this.data?.items ?? [];
+    }
+
+    statusClass(item) {
+        if (item.failures > 0 || item.success_rate < 95) {
+            return 'text-rose-600 dark:text-rose-300';
+        }
+
+        return 'text-emerald-600 dark:text-emerald-300';
+    }
+
+    @task *load() {
+        try {
+            this.data = yield this.fetch.get('metrics/dev/endpoint-health', { period: this.args.period ?? '30d' });
+            this.error = null;
+        } catch (error) {
+            this.error = error?.message ?? 'Unable to load endpoints';
+        }
+    }
+
+    @action refresh() {
+        this.load.perform();
+    }
+}

--- a/addon/components/widget/event-stream.hbs
+++ b/addon/components/widget/event-stream.hbs
@@ -1,0 +1,35 @@
+<div class="developers-dashboard-widget flex h-full flex-col overflow-hidden rounded-md border bg-white shadow-sm dark:bg-gray-800" ...attributes>
+    <div class="developers-widget-header">
+        <div class="min-w-0">
+            <div class="developers-widget-title">{{t "developers.component.widget.dashboard.event-stream.title"}}</div>
+            <div class="developers-widget-subtitle">{{t "developers.component.widget.dashboard.event-stream.subtitle"}}</div>
+        </div>
+        <button type="button" class="developers-widget-icon-button" {{on "click" this.refresh}} title={{t "developers.common.reload"}}>
+            <FaIcon @icon="rotate" class={{if this.load.isRunning "animate-spin"}} />
+        </button>
+    </div>
+    <div class="developers-widget-scroll-body">
+        {{#if this.load.isRunning}}
+            <div class="developers-empty-state"><Spinner /></div>
+        {{else if this.error}}
+            <div class="developers-empty-state text-rose-500">{{this.error}}</div>
+        {{else}}
+            <div class="developers-mini-section">{{t "developers.component.widget.dashboard.event-stream.types"}}</div>
+            {{#each this.types as |item|}}
+                <div class="developers-list-row">
+                    <div class="developers-list-title">{{item.label}}</div>
+                    <div class="developers-list-metric">{{item.value}}</div>
+                </div>
+            {{else}}
+                <div class="developers-empty-state">{{t "developers.component.widget.dashboard.empty"}}</div>
+            {{/each}}
+            <div class="developers-mini-section mt-3">{{t "developers.component.widget.dashboard.event-stream.sources"}}</div>
+            {{#each this.sources as |item|}}
+                <div class="developers-list-row">
+                    <div class="developers-list-title">{{item.label}}</div>
+                    <div class="developers-list-metric">{{item.value}}</div>
+                </div>
+            {{/each}}
+        {{/if}}
+    </div>
+</div>

--- a/addon/components/widget/event-stream.js
+++ b/addon/components/widget/event-stream.js
@@ -1,0 +1,38 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+
+export default class WidgetEventStreamComponent extends Component {
+    @service fetch;
+
+    @tracked data = null;
+    @tracked error = null;
+
+    constructor() {
+        super(...arguments);
+        this.load.perform();
+    }
+
+    get types() {
+        return this.data?.types ?? [];
+    }
+
+    get sources() {
+        return this.data?.sources ?? [];
+    }
+
+    @task *load() {
+        try {
+            this.data = yield this.fetch.get('metrics/dev/events', { period: this.args.period ?? '30d' });
+            this.error = null;
+        } catch (error) {
+            this.error = error?.message ?? 'Unable to load events';
+        }
+    }
+
+    @action refresh() {
+        this.load.perform();
+    }
+}

--- a/addon/components/widget/kpi-active-api-keys.hbs
+++ b/addon/components/widget/kpi-active-api-keys.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersKpiTile @metric="active_api_keys" @title={{t "developers.component.widget.dashboard.kpi.active-api-keys"}} @icon="key" @accent="indigo" />

--- a/addon/components/widget/kpi-active-api-keys.js
+++ b/addon/components/widget/kpi-active-api-keys.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetKpiActiveApiKeysComponent extends Component {
+    widget = 'active-api-keys';
+}

--- a/addon/components/widget/kpi-active-webhooks.hbs
+++ b/addon/components/widget/kpi-active-webhooks.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersKpiTile @metric="active_webhooks" @title={{t "developers.component.widget.dashboard.kpi.active-webhooks"}} @icon="plug-circle-check" @accent="cyan" />

--- a/addon/components/widget/kpi-active-webhooks.js
+++ b/addon/components/widget/kpi-active-webhooks.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetKpiActiveWebhooksComponent extends Component {
+    widget = 'active-webhooks';
+}

--- a/addon/components/widget/kpi-api-error-rate.hbs
+++ b/addon/components/widget/kpi-api-error-rate.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersKpiTile @metric="api_error_rate" @title={{t "developers.component.widget.dashboard.kpi.api-error-rate"}} @icon="triangle-exclamation" @accent="rose" />

--- a/addon/components/widget/kpi-api-error-rate.js
+++ b/addon/components/widget/kpi-api-error-rate.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetKpiApiErrorRateComponent extends Component {
+    widget = 'api-error-rate';
+}

--- a/addon/components/widget/kpi-api-latency.hbs
+++ b/addon/components/widget/kpi-api-latency.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersKpiTile @metric="avg_api_latency" @title={{t "developers.component.widget.dashboard.kpi.api-latency"}} @icon="gauge-high" @accent="amber" />

--- a/addon/components/widget/kpi-api-latency.js
+++ b/addon/components/widget/kpi-api-latency.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetKpiApiLatencyComponent extends Component {
+    widget = 'api-latency';
+}

--- a/addon/components/widget/kpi-api-requests.hbs
+++ b/addon/components/widget/kpi-api-requests.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersKpiTile @metric="api_requests" @title={{t "developers.component.widget.dashboard.kpi.api-requests"}} @icon="code" @accent="blue" />

--- a/addon/components/widget/kpi-api-requests.js
+++ b/addon/components/widget/kpi-api-requests.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetKpiApiRequestsComponent extends Component {
+    widget = 'api-requests';
+}

--- a/addon/components/widget/kpi-events-emitted.hbs
+++ b/addon/components/widget/kpi-events-emitted.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersKpiTile @metric="events_emitted" @title={{t "developers.component.widget.dashboard.kpi.events-emitted"}} @icon="bolt" @accent="indigo" />

--- a/addon/components/widget/kpi-events-emitted.js
+++ b/addon/components/widget/kpi-events-emitted.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetKpiEventsEmittedComponent extends Component {
+    widget = 'events-emitted';
+}

--- a/addon/components/widget/kpi-webhook-failures.hbs
+++ b/addon/components/widget/kpi-webhook-failures.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersKpiTile @metric="webhook_failures" @title={{t "developers.component.widget.dashboard.kpi.webhook-failures"}} @icon="webhook" @accent="rose" />

--- a/addon/components/widget/kpi-webhook-failures.js
+++ b/addon/components/widget/kpi-webhook-failures.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetKpiWebhookFailuresComponent extends Component {
+    widget = 'webhook-failures';
+}

--- a/addon/components/widget/kpi-webhook-success.hbs
+++ b/addon/components/widget/kpi-webhook-success.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersKpiTile @metric="webhook_success_rate" @title={{t "developers.component.widget.dashboard.kpi.webhook-success"}} @icon="webhook" @accent="emerald" />

--- a/addon/components/widget/kpi-webhook-success.js
+++ b/addon/components/widget/kpi-webhook-success.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetKpiWebhookSuccessComponent extends Component {
+    widget = 'webhook-success';
+}

--- a/addon/components/widget/quick-resources.hbs
+++ b/addon/components/widget/quick-resources.hbs
@@ -1,0 +1,17 @@
+<div class="developers-dashboard-widget flex h-full flex-col overflow-hidden rounded-md border bg-white shadow-sm dark:bg-gray-800" ...attributes>
+    <div class="developers-widget-header">
+        <div class="min-w-0">
+            <div class="developers-widget-title">{{t "developers.component.widget.dashboard.quick-resources.title"}}</div>
+            <div class="developers-widget-subtitle">{{t "developers.component.widget.dashboard.quick-resources.subtitle"}}</div>
+        </div>
+    </div>
+    <div class="developers-widget-scroll-body">
+        {{#each this.resources as |resource|}}
+            <LinkTo @route={{resource.route}} class="developers-resource-link">
+                <span class="developers-activity-icon"><FaIcon @icon={{resource.icon}} /></span>
+                <span class="min-w-0 truncate">{{resource.label}}</span>
+                <FaIcon @icon="arrow-right" class="ml-auto text-[10px] text-gray-400" />
+            </LinkTo>
+        {{/each}}
+    </div>
+</div>

--- a/addon/components/widget/quick-resources.js
+++ b/addon/components/widget/quick-resources.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class WidgetQuickResourcesComponent extends Component {
+    resources = [
+        { label: 'API Keys', route: 'api-keys.index', icon: 'key' },
+        { label: 'Webhooks', route: 'webhooks.index', icon: 'webhook' },
+        { label: 'Logs', route: 'logs.index', icon: 'terminal' },
+        { label: 'Events', route: 'events.index', icon: 'bolt' },
+        { label: 'Sockets', route: 'sockets.index', icon: 'plug' },
+    ];
+}

--- a/addon/components/widget/quick-resources.js
+++ b/addon/components/widget/quick-resources.js
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 export default class WidgetQuickResourcesComponent extends Component {
     resources = [
         { label: 'API Keys', route: 'api-keys.index', icon: 'key' },
-        { label: 'Webhooks', route: 'webhooks.index', icon: 'webhook' },
+        { label: 'Webhooks', route: 'webhooks.index', icon: 'globe' },
         { label: 'Logs', route: 'logs.index', icon: 'terminal' },
         { label: 'Events', route: 'events.index', icon: 'bolt' },
         { label: 'Sockets', route: 'sockets.index', icon: 'plug' },

--- a/addon/components/widget/webhook-delivery.hbs
+++ b/addon/components/widget/webhook-delivery.hbs
@@ -1,0 +1,1 @@
+<Widget::DevelopersChart @endpoint="webhook-delivery" @title={{t "developers.component.widget.dashboard.webhook-delivery.title"}} @subtitle={{t "developers.component.widget.dashboard.webhook-delivery.subtitle"}} />

--- a/addon/components/widget/webhook-delivery.js
+++ b/addon/components/widget/webhook-delivery.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class WidgetWebhookDeliveryComponent extends Component {
+    widget = 'webhook-delivery';
+}

--- a/addon/controllers/api-keys/index.js
+++ b/addon/controllers/api-keys/index.js
@@ -28,7 +28,7 @@ export default class ApiKeysIndexController extends Controller {
      *
      * @var {Array}
      */
-    queryParams = ['page', 'limit', 'sort'];
+    queryParams = ['page', 'limit', 'sort', 'query', 'view_api_key'];
 
     /**
      * Expiration options for api keys
@@ -71,6 +71,13 @@ export default class ApiKeysIndexController extends Controller {
      * @var {String}
      */
     @tracked query;
+
+    /**
+     * Deep-linked API key to open in the edit modal.
+     *
+     * @var {String}
+     */
+    @tracked view_api_key;
 
     /**
      * Checks if console environment is in live mode
@@ -508,5 +515,33 @@ export default class ApiKeysIndexController extends Controller {
      */
     @action reload() {
         return this.hostRouter.refresh();
+    }
+
+    @action async openDeepLinkedApiKey() {
+        const apiKeyId = this.view_api_key;
+
+        if (!apiKeyId) {
+            return;
+        }
+
+        try {
+            const apiKey = this.store.peekRecord('api-credential', apiKeyId) ?? (await this.store.findRecord('api-credential', apiKeyId));
+            this.editApiKey(apiKey, {
+                onDecline: this.clearDeepLinkedApiKey,
+                onFinish: this.clearDeepLinkedApiKey,
+            });
+        } catch (_) {
+            this.notifications.warning('Unable to open the selected API key.');
+            this.clearDeepLinkedApiKey();
+        }
+    }
+
+    @action clearDeepLinkedApiKey() {
+        if (!this.view_api_key) {
+            return;
+        }
+
+        this.view_api_key = null;
+        this.hostRouter.transitionTo({ queryParams: { view_api_key: null } });
     }
 }

--- a/addon/controllers/application.js
+++ b/addon/controllers/application.js
@@ -1,0 +1,94 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+export default class ApplicationController extends Controller {
+    @service intl;
+    @service abilities;
+    @service fetch;
+
+    get navigationItems() {
+        return [
+            {
+                label: this.intl.t('developers.application.sidebar.items.home'),
+                description: 'Developer dashboard and API health overview.',
+                icon: 'home',
+                route: 'console.developers.home',
+                keywords: ['dashboard', 'overview', 'metrics'],
+            },
+            {
+                label: this.intl.t('developers.application.sidebar.items.api-keys'),
+                description: 'Create and manage API credentials.',
+                icon: 'key',
+                route: 'console.developers.api-keys',
+                permission: 'developers list api-key',
+                visible: this.can('developers see api-key'),
+                keywords: ['credentials', 'access keys', 'sandbox', 'live keys'],
+            },
+            {
+                label: this.intl.t('developers.application.sidebar.items.webhooks'),
+                description: 'Configure webhook endpoints.',
+                icon: 'globe-asia',
+                route: 'console.developers.webhooks',
+                permission: 'developers list webhook',
+                visible: this.can('developers see webhook'),
+                keywords: ['endpoints', 'callbacks', 'notifications'],
+            },
+            {
+                label: this.intl.t('developers.application.sidebar.items.websockets'),
+                description: 'Inspect websocket channels.',
+                icon: 'plug',
+                route: 'console.developers.sockets',
+                permission: 'developers list socket',
+                visible: this.can('developers see socket'),
+                keywords: ['sockets', 'channels', 'realtime'],
+            },
+            {
+                label: this.intl.t('developers.application.sidebar.items.logs'),
+                description: 'Review API request logs.',
+                icon: 'file-lines',
+                route: 'console.developers.logs',
+                permission: 'developers list log',
+                visible: this.can('developers see log'),
+                keywords: ['requests', 'traffic', 'debugging'],
+            },
+            {
+                label: this.intl.t('developers.application.sidebar.items.events'),
+                description: 'Browse platform events.',
+                icon: 'calendar-day',
+                route: 'console.developers.events',
+                permission: 'developers list event',
+                visible: this.can('developers see event'),
+                keywords: ['event stream', 'activity', 'webhook events'],
+            },
+        ];
+    }
+
+    can(permission) {
+        try {
+            return this.abilities.can(permission);
+        } catch (_) {
+            return true;
+        }
+    }
+
+    @action
+    async searchNavigation({ query, limit = 12 }) {
+        const trimmedQuery = query?.trim();
+
+        if (!trimmedQuery) {
+            return [];
+        }
+
+        try {
+            const response = await this.fetch.get('developers/search', {
+                query: trimmedQuery,
+                limit,
+            });
+
+            return response.results ?? [];
+        } catch (_) {
+            return [];
+        }
+    }
+}

--- a/addon/extension.js
+++ b/addon/extension.js
@@ -20,7 +20,7 @@ export default {
                 {
                     title: 'Webhooks',
                     description: 'Configure webhook endpoints to receive real-time event notifications.',
-                    icon: 'webhook',
+                    icon: 'globe',
                     route: 'console.developers.webhooks',
                 },
                 {
@@ -211,13 +211,13 @@ export default {
 
         widgetService.registerDashboard('developers');
         widgetService.registerWidgets('developers', widgets);
-        widgetService.registerWidgets('dashboard', [
-            getWidgetById('developers-kpi-api-error-rate'),
-            getWidgetById('developers-kpi-api-latency'),
-            getWidgetById('developers-kpi-webhook-success'),
-            getWidgetById('developers-api-traffic', (widget) => {
-                widget.withGridOptions({ w: 6, h: 7, minW: 5, minH: 6 });
-            }),
-        ]);
+        // widgetService.registerWidgets('dashboard', [
+        //     getWidgetById('developers-kpi-api-error-rate'),
+        //     getWidgetById('developers-kpi-api-latency'),
+        //     getWidgetById('developers-kpi-webhook-success'),
+        //     getWidgetById('developers-api-traffic', (widget) => {
+        //         widget.withGridOptions({ w: 6, h: 7, minW: 5, minH: 6 });
+        //     }),
+        // ]);
     },
 };

--- a/addon/extension.js
+++ b/addon/extension.js
@@ -44,19 +44,180 @@ export default {
             ],
         });
 
-        // Register widgets
+        // Register dashboard and widgets
         const widgets = [
             new Widget({
+                id: 'developers-kpi-api-requests',
+                name: 'API Requests',
+                description: 'Total API requests for the current period.',
+                icon: 'code',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/kpi-api-requests'),
+                grid_options: { w: 3, h: 4, minW: 3, minH: 4 },
+                category: 'KPI Tiles',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-kpi-api-error-rate',
+                name: 'API Error Rate',
+                description: 'Percentage of API requests returning an error.',
+                icon: 'triangle-exclamation',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/kpi-api-error-rate'),
+                grid_options: { w: 3, h: 4, minW: 3, minH: 4 },
+                category: 'KPI Tiles',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-kpi-api-latency',
+                name: 'Avg API Latency',
+                description: 'Average API response duration for the current period.',
+                icon: 'gauge-high',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/kpi-api-latency'),
+                grid_options: { w: 3, h: 4, minW: 3, minH: 4 },
+                category: 'KPI Tiles',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-kpi-webhook-success',
+                name: 'Webhook Success Rate',
+                description: 'Percentage of webhook deliveries returning a 2xx response.',
+                icon: 'webhook',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/kpi-webhook-success'),
+                grid_options: { w: 3, h: 4, minW: 3, minH: 4 },
+                category: 'KPI Tiles',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-kpi-active-api-keys',
+                name: 'Active API Keys',
+                description: 'Active API credentials in this organization.',
+                icon: 'key',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/kpi-active-api-keys'),
+                grid_options: { w: 3, h: 4, minW: 3, minH: 4 },
+                category: 'KPI Tiles',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-kpi-active-webhooks',
+                name: 'Active Webhooks',
+                description: 'Enabled webhook endpoints in this organization.',
+                icon: 'plug-circle-check',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/kpi-active-webhooks'),
+                grid_options: { w: 3, h: 4, minW: 3, minH: 4 },
+                category: 'KPI Tiles',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-kpi-webhook-failures',
+                name: 'Webhook Failures',
+                description: 'Failed webhook deliveries for the current period.',
+                icon: 'webhook',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/kpi-webhook-failures'),
+                grid_options: { w: 3, h: 4, minW: 3, minH: 4 },
+                category: 'KPI Tiles',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-kpi-events-emitted',
+                name: 'Events Emitted',
+                description: 'Platform events emitted in the current period.',
+                icon: 'bolt',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/kpi-events-emitted'),
+                grid_options: { w: 3, h: 4, minW: 3, minH: 4 },
+                category: 'KPI Tiles',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-api-traffic',
+                name: 'API Traffic',
+                description: 'API request volume, successes, and errors over time.',
+                icon: 'chart-line',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/api-traffic'),
+                grid_options: { w: 6, h: 8, minW: 5, minH: 7 },
+                category: 'Analytics',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-webhook-delivery',
+                name: 'Webhook Delivery Health',
+                description: 'Webhook delivery volume, success, failure, and retry health.',
+                icon: 'chart-column',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/webhook-delivery'),
+                grid_options: { w: 6, h: 8, minW: 5, minH: 7 },
+                category: 'Analytics',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-endpoint-health',
+                name: 'Endpoint Health',
+                description: 'Webhook endpoint delivery health and recent failures.',
+                icon: 'heart-pulse',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/endpoint-health'),
+                grid_options: { w: 6, h: 8, minW: 5, minH: 7 },
+                category: 'Operations',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-event-stream',
+                name: 'Event Stream',
+                description: 'Top event types and event sources in the selected period.',
+                icon: 'bolt',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/event-stream'),
+                grid_options: { w: 6, h: 8, minW: 5, minH: 7 },
+                category: 'Operations',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-activity',
+                name: 'Developer Activity',
+                description: 'Recent API requests, webhook deliveries, and events.',
+                icon: 'timeline',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/developer-activity'),
+                grid_options: { w: 6, h: 8, minW: 5, minH: 7 },
+                category: 'Operations',
+                default: true,
+            }),
+            new Widget({
+                id: 'developers-quick-resources',
+                name: 'Quick Resources',
+                description: 'Shortcuts into API keys, webhooks, logs, events, and sockets.',
+                icon: 'link',
+                component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/quick-resources'),
+                grid_options: { w: 6, h: 8, minW: 5, minH: 7 },
+                category: 'Resources',
+                default: true,
+            }),
+            new Widget({
                 id: 'dev-api-metrics-widget',
-                name: 'Developer API Metrics',
-                description: 'Key metrics from API Usage.',
+                name: 'Developer API Metrics (Legacy)',
+                description: 'Legacy grouped monitoring widget. Replaced by individual developer dashboard widgets.',
                 icon: 'code',
                 component: new ExtensionComponent('@fleetbase/dev-engine', 'widget/api-metrics'),
                 grid_options: { w: 12, h: 12, minW: 8, minH: 12 },
                 options: { title: 'API Metrics' },
+                category: 'Legacy',
+                default: false,
             }),
         ];
 
-        widgetService.registerWidgets('dashboard', widgets);
+        const getWidgetById = (id = null, mutate = null) => {
+            if (!id) return null;
+            const widget = widgets.find((w) => w.id === id);
+            const clone = new Widget(widget.toObject());
+            if (typeof mutate === 'function') {
+                mutate(clone);
+            }
+            return clone;
+        };
+
+        widgetService.registerDashboard('developers');
+        widgetService.registerWidgets('developers', widgets);
+        widgetService.registerWidgets('dashboard', [
+            getWidgetById('developers-kpi-api-error-rate'),
+            getWidgetById('developers-kpi-api-latency'),
+            getWidgetById('developers-kpi-webhook-success'),
+            getWidgetById('developers-api-traffic', (widget) => {
+                widget.withGridOptions({ w: 6, h: 7, minW: 5, minH: 6 });
+            }),
+        ]);
     },
 };

--- a/addon/routes/api-keys/index.js
+++ b/addon/routes/api-keys/index.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { later } from '@ember/runloop';
 
 export default class ApiKeysIndexRoute extends Route {
     @service store;
@@ -21,6 +22,9 @@ export default class ApiKeysIndexRoute extends Route {
         query: {
             refreshModel: true,
         },
+        view_api_key: {
+            refreshModel: false,
+        },
         sort: {
             refreshModel: true,
         },
@@ -38,10 +42,15 @@ export default class ApiKeysIndexRoute extends Route {
     }
 
     model(params) {
-        return this.store.query('api-credential', { ...params });
+        const queryParams = { ...params };
+        delete queryParams.view_api_key;
+
+        return this.store.query('api-credential', { ...queryParams });
     }
 
     setupController(controller) {
+        super.setupController(...arguments);
         controller.testMode = this.currentUser.getOption('sandbox', false);
+        later(controller, controller.openDeepLinkedApiKey);
     }
 }

--- a/addon/styles/dev-engine.css
+++ b/addon/styles/dev-engine.css
@@ -50,3 +50,323 @@ body[data-theme='dark'] .webhook-attempts-date-filter-container > .date-filter-l
     height: 100%;
     width: 100%;
 }
+
+.developers-dashboard-widget {
+    min-width: 0;
+    border-color: #e5e7eb;
+    background-color: #fff;
+    animation: developers-widget-fade-up 320ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    transition:
+        border-color 180ms ease,
+        box-shadow 180ms ease;
+}
+
+.developers-dashboard-widget:hover {
+    border-color: #cbd5e1;
+    box-shadow: 0 10px 28px -22px rgb(15 23 42 / 45%);
+}
+
+body[data-theme='dark'] .developers-dashboard-widget {
+    border-color: #374151;
+    background-color: #1f2937;
+}
+
+@keyframes developers-widget-fade-up {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.developers-dashboard-page {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid #e5e7eb;
+    background-color: #fff;
+    padding: 1rem;
+    box-shadow: 0 1px 2px rgb(15 23 42 / 6%);
+}
+
+body[data-theme='dark'] .developers-dashboard-page {
+    border-bottom-color: #1f2937;
+    background-color: #111827;
+    box-shadow: 0 1px 2px rgb(2 6 23 / 30%);
+}
+
+.developers-dashboard-title h1 {
+    color: #111827;
+    font-size: 1.05rem;
+    font-weight: 800;
+    line-height: 1.2;
+}
+
+body[data-theme='dark'] .developers-dashboard-title h1 {
+    color: #f9fafb;
+}
+
+.developers-dashboard-actions {
+    justify-content: flex-end;
+}
+
+.developers-dashboard-create-wrapper {
+    padding: 1rem;
+}
+
+.developers-widget-header {
+    display: flex;
+    min-height: 3.25rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border-bottom: 1px solid #e5e7eb;
+    padding: 0.75rem;
+}
+
+body[data-theme='dark'] .developers-widget-header {
+    border-bottom-color: #374151;
+}
+
+.developers-widget-title {
+    overflow: hidden;
+    color: #111827;
+    font-size: 0.82rem;
+    font-weight: 800;
+    line-height: 1.2;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+body[data-theme='dark'] .developers-widget-title {
+    color: #f9fafb;
+}
+
+.developers-widget-subtitle,
+.developers-list-subtitle {
+    overflow: hidden;
+    color: #6b7280;
+    font-size: 0.69rem;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+body[data-theme='dark'] .developers-widget-subtitle,
+body[data-theme='dark'] .developers-list-subtitle {
+    color: #9ca3af;
+}
+
+.developers-widget-icon-button,
+.developers-kpi-icon {
+    width: 1.75rem;
+    height: 1.75rem;
+    flex: 0 0 1.75rem;
+    color: #64748b;
+}
+
+.developers-widget-icon-button:hover,
+.developers-kpi-icon:hover {
+    color: #111827;
+}
+
+body[data-theme='dark'] .developers-widget-icon-button:hover,
+body[data-theme='dark'] .developers-kpi-icon:hover {
+    color: #f9fafb;
+}
+
+.developers-kpi-label {
+    color: #6b7280;
+    font-size: 0.625rem;
+    font-weight: 800;
+    line-height: 1.15;
+    text-transform: uppercase;
+}
+
+body[data-theme='dark'] .developers-kpi-label {
+    color: #9ca3af;
+}
+
+.developers-kpi-value {
+    color: #111827;
+    font-size: 1.45rem;
+    font-weight: 800;
+    line-height: 1;
+}
+
+body[data-theme='dark'] .developers-kpi-value {
+    color: #f9fafb;
+}
+
+.developers-kpi-delta {
+    max-width: 5.5rem;
+}
+
+.developers-kpi-accent-blue {
+    background-image: linear-gradient(135deg, rgb(37 99 235 / 12%) 0%, rgb(37 99 235 / 0%) 64%);
+}
+
+.developers-kpi-accent-rose {
+    background-image: linear-gradient(135deg, rgb(225 29 72 / 12%) 0%, rgb(225 29 72 / 0%) 64%);
+}
+
+.developers-kpi-accent-amber {
+    background-image: linear-gradient(135deg, rgb(245 158 11 / 14%) 0%, rgb(245 158 11 / 0%) 64%);
+}
+
+.developers-kpi-accent-emerald {
+    background-image: linear-gradient(135deg, rgb(16 185 129 / 12%) 0%, rgb(16 185 129 / 0%) 64%);
+}
+
+.developers-kpi-accent-indigo {
+    background-image: linear-gradient(135deg, rgb(79 70 229 / 12%) 0%, rgb(79 70 229 / 0%) 64%);
+}
+
+.developers-kpi-accent-cyan {
+    background-image: linear-gradient(135deg, rgb(6 182 212 / 12%) 0%, rgb(6 182 212 / 0%) 64%);
+}
+
+.developers-chart-widget {
+    overflow: hidden;
+}
+
+.developers-chart-body {
+    display: flex;
+    min-height: 0;
+    min-width: 0;
+    flex: 1 1 auto;
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 0.75rem;
+}
+
+.developers-chart-frame {
+    position: relative;
+    min-height: 0;
+    width: 100%;
+    flex: 1 1 auto;
+}
+
+.developers-dashboard-widget .ui-chart {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+
+.developers-dashboard-widget .ui-chart > canvas {
+    position: absolute;
+    inset: 0;
+    width: 100% !important;
+    height: 100% !important;
+}
+
+.developers-widget-scroll-body {
+    min-height: 0;
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 0.5rem;
+}
+
+.developers-list-row,
+.developers-activity-row,
+.developers-resource-link {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.65rem;
+    border-radius: 0.375rem;
+    padding: 0.5rem;
+}
+
+.developers-resource-link {
+    color: #111827;
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.developers-list-row + .developers-list-row,
+.developers-activity-row + .developers-activity-row,
+.developers-resource-link + .developers-resource-link {
+    margin-top: 0.25rem;
+}
+
+.developers-list-row:hover,
+.developers-activity-row:hover,
+.developers-resource-link:hover {
+    background-color: #f8fafc;
+}
+
+body[data-theme='dark'] .developers-resource-link {
+    color: #f9fafb;
+}
+
+body[data-theme='dark'] .developers-list-row:hover,
+body[data-theme='dark'] .developers-activity-row:hover,
+body[data-theme='dark'] .developers-resource-link:hover {
+    background-color: #111827;
+}
+
+.developers-list-title {
+    min-width: 0;
+    overflow: hidden;
+    color: #111827;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+body[data-theme='dark'] .developers-list-title {
+    color: #f9fafb;
+}
+
+.developers-list-metric {
+    margin-left: auto;
+    flex: 0 0 auto;
+    font-size: 0.78rem;
+    font-weight: 800;
+}
+
+.developers-activity-icon {
+    display: flex;
+    width: 1.75rem;
+    height: 1.75rem;
+    flex: 0 0 1.75rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.375rem;
+    background-color: #eff6ff;
+    color: #2563eb;
+    font-size: 0.75rem;
+}
+
+body[data-theme='dark'] .developers-activity-icon {
+    background-color: rgb(37 99 235 / 16%);
+    color: #93c5fd;
+}
+
+.developers-mini-section {
+    padding: 0.25rem 0.5rem;
+    color: #64748b;
+    font-size: 0.62rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.developers-empty-state {
+    display: flex;
+    min-height: 5rem;
+    align-items: center;
+    justify-content: center;
+    color: #64748b;
+    font-size: 0.75rem;
+    font-weight: 600;
+}

--- a/addon/templates/application.hbs
+++ b/addon/templates/application.hbs
@@ -1,13 +1,5 @@
 <EmberWormhole @to="sidebar-menu-items">
-    <Layout::Sidebar::Panel @open={{true}} @title={{t "developers.application.sidebar.title"}}>
-        <Layout::Sidebar::Item @route="console.developers.home" @icon="home">{{t "developers.application.sidebar.items.home"}}</Layout::Sidebar::Item>
-        <Layout::Sidebar::Item @route="console.developers.api-keys" @icon="key" @permission="developers list api-key" @visible={{can "developers see api-key"}}>{{t "developers.application.sidebar.items.api-keys"}}</Layout::Sidebar::Item>
-        <Layout::Sidebar::Item @route="console.developers.webhooks" @icon="globe-asia" @permission="developers list webhook" @visible={{can "developers see webhook"}}>{{t "developers.application.sidebar.items.webhooks"}}</Layout::Sidebar::Item>
-        <Layout::Sidebar::Item @route="console.developers.sockets" @icon="plug" @permission="developers list socket" @visible={{can "developers see socket"}}>{{t "developers.application.sidebar.items.websockets"}}</Layout::Sidebar::Item>
-        <Layout::Sidebar::Item @route="console.developers.logs" @icon="file-lines" @permission="developers list log" @visible={{can "developers see log"}}>{{t "developers.application.sidebar.items.logs"}}</Layout::Sidebar::Item>
-        <Layout::Sidebar::Item @route="console.developers.events" @icon="calendar-day" @permission="developers list event" @visible={{can "developers see event"}}>{{t "developers.application.sidebar.items.events"}}</Layout::Sidebar::Item>
-    </Layout::Sidebar::Panel>
-
+    <Layout::Sidebar::Navigator @items={{this.navigationItems}} @searchPlaceholder="Search Dev..." @searchProvider={{this.searchNavigation}} />
 </EmberWormhole>
 
 <Layout::Section::Container>

--- a/addon/templates/home/index.hbs
+++ b/addon/templates/home/index.hbs
@@ -1,3 +1,14 @@
-<Layout::Section::Body class="mx-auto max-w-6xl p-8 h-full overflow-y-scroll">
-    <Widget::ApiMetrics />
+<Layout::Section::Body class="overflow-y-scroll h-full">
+    <Dashboard
+        @defaultDashboardId="developers"
+        @defaultDashboardName={{t "developers.component.widget.dashboard.name"}}
+        @extension="developers"
+        @leftHeaderWrapperClass="developers-dashboard-title"
+        @rightHeaderWrapperClass="developers-dashboard-actions"
+        @createWrapperClass="developers-dashboard-create-wrapper"
+        @stickyHeader={{true}}
+        class="developers-dashboard-page"
+    />
+    <Spacer @height="300px" />
+    {{outlet}}
 </Layout::Section::Body>

--- a/app/components/widget/api-traffic.js
+++ b/app/components/widget/api-traffic.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/api-traffic';

--- a/app/components/widget/developer-activity.js
+++ b/app/components/widget/developer-activity.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/developer-activity';

--- a/app/components/widget/developers-chart.js
+++ b/app/components/widget/developers-chart.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/developers-chart';

--- a/app/components/widget/developers-kpi-tile.js
+++ b/app/components/widget/developers-kpi-tile.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/developers-kpi-tile';

--- a/app/components/widget/endpoint-health.js
+++ b/app/components/widget/endpoint-health.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/endpoint-health';

--- a/app/components/widget/event-stream.js
+++ b/app/components/widget/event-stream.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/event-stream';

--- a/app/components/widget/kpi-active-api-keys.js
+++ b/app/components/widget/kpi-active-api-keys.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/kpi-active-api-keys';

--- a/app/components/widget/kpi-active-webhooks.js
+++ b/app/components/widget/kpi-active-webhooks.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/kpi-active-webhooks';

--- a/app/components/widget/kpi-api-error-rate.js
+++ b/app/components/widget/kpi-api-error-rate.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/kpi-api-error-rate';

--- a/app/components/widget/kpi-api-latency.js
+++ b/app/components/widget/kpi-api-latency.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/kpi-api-latency';

--- a/app/components/widget/kpi-api-requests.js
+++ b/app/components/widget/kpi-api-requests.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/kpi-api-requests';

--- a/app/components/widget/kpi-events-emitted.js
+++ b/app/components/widget/kpi-events-emitted.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/kpi-events-emitted';

--- a/app/components/widget/kpi-webhook-failures.js
+++ b/app/components/widget/kpi-webhook-failures.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/kpi-webhook-failures';

--- a/app/components/widget/kpi-webhook-success.js
+++ b/app/components/widget/kpi-webhook-success.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/kpi-webhook-success';

--- a/app/components/widget/quick-resources.js
+++ b/app/components/widget/quick-resources.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/quick-resources';

--- a/app/components/widget/webhook-delivery.js
+++ b/app/components/widget/webhook-delivery.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/components/widget/webhook-delivery';

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/dev-engine/controllers/application';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9421,7 +9421,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  '@ember-data/adapter@4.12.8(@ember-data/store@4.12.8(@babel/core@7.28.5)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))':
+  '@ember-data/adapter@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.28.5)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0))
@@ -9552,7 +9552,7 @@ snapshots:
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/serializer@4.12.8(@ember-data/store@4.12.8(@babel/core@7.28.5)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))':
+  '@ember-data/serializer@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.28.5)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0))
@@ -13698,7 +13698,7 @@ snapshots:
 
   ember-data@4.12.8(@babel/core@7.28.5)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0))(webpack@5.103.0):
     dependencies:
-      '@ember-data/adapter': 4.12.8(@ember-data/store@4.12.8(@babel/core@7.28.5)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))
+      '@ember-data/adapter': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))
       '@ember-data/debug': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(webpack@5.103.0)
       '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)
       '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)
@@ -13706,7 +13706,7 @@ snapshots:
       '@ember-data/model': 4.12.8(@babel/core@7.28.5)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0))
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/request': 4.12.8
-      '@ember-data/serializer': 4.12.8(@ember-data/store@4.12.8(@babel/core@7.28.5)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))
+      '@ember-data/serializer': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0)))
       '@ember-data/store': 4.12.8(@babel/core@7.28.5)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.1(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)(webpack@5.103.0))
       '@ember-data/tracking': 4.12.8
       '@ember/edition-utils': 1.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+allowBuilds:
+  '@fortawesome/fontawesome-common-types': false
+  '@fortawesome/fontawesome-svg-core': false
+  '@fortawesome/free-brands-svg-icons': false
+  '@fortawesome/free-solid-svg-icons': false
+  core-js: false
+  fsevents: false
+minimumReleaseAge: 0

--- a/tests/integration/components/widget/developers-kpi-tile-test.js
+++ b/tests/integration/components/widget/developers-kpi-tile-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import Service from '@ember/service';
+import { hbs } from 'ember-cli-htmlbars';
+
+class FetchStub extends Service {
+    get() {
+        return Promise.resolve({
+            metrics: {
+                api_requests: {
+                    label: 'API Requests',
+                    value: 42,
+                    format: 'count',
+                    delta_percent: 12,
+                },
+            },
+        });
+    }
+}
+
+module('Integration | Component | widget/developers-kpi-tile', function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+        this.owner.register('service:fetch', FetchStub);
+    });
+
+    test('it renders a dashboard KPI metric', async function (assert) {
+        await render(hbs`<Widget::DevelopersKpiTile @metric="api_requests" @title="API Requests" @icon="code" />`);
+
+        assert.dom('.developers-kpi-tile').exists();
+        assert.dom('.developers-kpi-label').hasText('API Requests');
+        assert.dom('.developers-kpi-value').hasText('42');
+    });
+});

--- a/tests/integration/components/widget/quick-resources-test.js
+++ b/tests/integration/components/widget/quick-resources-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | widget/quick-resources', function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders developer resource shortcuts', async function (assert) {
+        await render(hbs`<Widget::QuickResources />`);
+
+        assert.dom('.developers-dashboard-widget').exists();
+        assert.dom('.developers-resource-link').exists({ count: 5 });
+        assert.dom('.developers-resource-link').includesText('API Keys');
+        assert.dom('.developers-resource-link').includesText('Webhooks');
+    });
+});

--- a/tests/unit/controllers/api-keys/index-test.js
+++ b/tests/unit/controllers/api-keys/index-test.js
@@ -1,12 +1,125 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'dummy/tests/helpers';
 
+class IntlStub {
+    t(key) {
+        return key;
+    }
+}
+
+class CurrentUserStub {
+    options = {};
+    user = {};
+
+    getOption(key, defaultValue = null) {
+        return key in this.options ? this.options[key] : defaultValue;
+    }
+
+    setOption(key, value) {
+        this.options[key] = value;
+    }
+}
+
+class AbilitiesStub {
+    cannot() {
+        return false;
+    }
+}
+
+class StoreStub {
+    record = { id: 'api_key_uuid', name: 'Live API Key' };
+    findRequests = [];
+
+    peekRecord() {
+        return null;
+    }
+
+    findRecord(modelName, id) {
+        this.findRequests.push({ modelName, id });
+        return Promise.resolve(this.record);
+    }
+}
+
+class HostRouterStub {
+    transitions = [];
+
+    transitionTo(...args) {
+        this.transitions.push(args);
+        return Promise.resolve();
+    }
+
+    refresh() {
+        return Promise.resolve();
+    }
+}
+
+class ModalsManagerStub {
+    show() {}
+    confirm() {}
+}
+
+class NotificationsStub {
+    warnings = [];
+
+    warning(message) {
+        this.warnings.push(message);
+    }
+
+    serverError() {}
+    success() {}
+}
+
+class EmptyServiceStub {}
+
 module('Unit | Controller | api-keys/index', function (hooks) {
     setupTest(hooks);
 
-    // TODO: Replace this with your real tests.
+    hooks.beforeEach(function () {
+        this.owner.register('service:intl', IntlStub);
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.owner.register('service:abilities', AbilitiesStub);
+        this.owner.register('service:store', StoreStub);
+        this.owner.register('service:host-router', HostRouterStub);
+        this.owner.register('service:modals-manager', ModalsManagerStub);
+        this.owner.register('service:notifications', NotificationsStub);
+        this.owner.register('service:crud', EmptyServiceStub);
+        this.owner.register('service:fetch', EmptyServiceStub);
+        this.owner.register('service:theme', EmptyServiceStub);
+        this.owner.register('service:universe', EmptyServiceStub);
+    });
+
     test('it exists', function (assert) {
         let controller = this.owner.lookup('controller:api-keys/index');
         assert.ok(controller);
+    });
+
+    test('it opens a deep-linked API key in the existing edit modal', async function (assert) {
+        const controller = this.owner.lookup('controller:api-keys/index');
+        const store = this.owner.lookup('service:store');
+
+        controller.view_api_key = 'api_key_uuid';
+        controller.editApiKey = (apiKey, options) => {
+            assert.strictEqual(apiKey, store.record);
+            assert.strictEqual(typeof options.onDecline, 'function');
+            assert.strictEqual(typeof options.onFinish, 'function');
+        };
+
+        await controller.openDeepLinkedApiKey();
+
+        assert.deepEqual(store.findRequests, [{ modelName: 'api-credential', id: 'api_key_uuid' }]);
+    });
+
+    test('it clears only the API key deep-link query param', function (assert) {
+        const controller = this.owner.lookup('controller:api-keys/index');
+        const hostRouter = this.owner.lookup('service:host-router');
+
+        controller.query = 'live';
+        controller.view_api_key = 'api_key_uuid';
+
+        controller.clearDeepLinkedApiKey();
+
+        assert.strictEqual(controller.view_api_key, null);
+        assert.strictEqual(controller.query, 'live', 'table query is preserved');
+        assert.deepEqual(hostRouter.transitions, [[{ queryParams: { view_api_key: null } }]]);
     });
 });

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -1,0 +1,114 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+class IntlStub {
+    translations = {
+        'developers.application.sidebar.items.home': 'Dashboard',
+        'developers.application.sidebar.items.api-keys': 'API Keys',
+        'developers.application.sidebar.items.webhooks': 'Webhooks',
+        'developers.application.sidebar.items.websockets': 'WebSockets',
+        'developers.application.sidebar.items.logs': 'Logs',
+        'developers.application.sidebar.items.events': 'Events',
+    };
+
+    t(key) {
+        return this.translations[key] ?? key;
+    }
+}
+
+class AbilitiesStub {
+    denied = new Set();
+
+    can(permission) {
+        return !this.denied.has(permission);
+    }
+}
+
+class FetchStub {
+    requests = [];
+    response = {
+        results: [
+            {
+                label: 'Live API Key',
+                description: 'flb_live_123',
+                icon: 'key',
+                type: 'API Key',
+                route: 'console.developers.api-keys.index',
+                breadcrumb: 'Developers > API Keys',
+                queryParams: { query: 'live', view_api_key: 'api_key_uuid' },
+            },
+        ],
+    };
+
+    get(url, params) {
+        this.requests.push({ url, params });
+        return Promise.resolve(this.response);
+    }
+}
+
+module('Unit | Controller | application', function (hooks) {
+    setupTest(hooks);
+
+    hooks.beforeEach(function () {
+        this.owner.register('service:intl', IntlStub);
+        this.owner.register('service:abilities', AbilitiesStub);
+        this.owner.register('service:fetch', FetchStub);
+    });
+
+    test('it builds developer sidebar navigator items with host routes', function (assert) {
+        const controller = this.owner.lookup('controller:application');
+        const items = controller.navigationItems;
+
+        assert.deepEqual(
+            items.map((item) => item.label),
+            ['Dashboard', 'API Keys', 'Webhooks', 'WebSockets', 'Logs', 'Events'],
+            'root items keep the developer labels'
+        );
+        assert.deepEqual(
+            items.map((item) => item.route),
+            ['console.developers.home', 'console.developers.api-keys', 'console.developers.webhooks', 'console.developers.sockets', 'console.developers.logs', 'console.developers.events'],
+            'root items keep the console host route names'
+        );
+        assert.strictEqual(items[1].permission, 'developers list api-key');
+        assert.true(items[1].visible, 'api keys item is visible when the see permission is allowed');
+    });
+
+    test('it marks developer navigator items hidden when see permissions are denied', function (assert) {
+        const abilities = this.owner.lookup('service:abilities');
+        abilities.denied.add('developers see webhook');
+
+        const controller = this.owner.lookup('controller:application');
+        const webhooks = controller.navigationItems.find((item) => item.route === 'console.developers.webhooks');
+
+        assert.false(webhooks.visible);
+    });
+
+    test('it fetches developer resource search results for the sidebar navigator', async function (assert) {
+        const controller = this.owner.lookup('controller:application');
+        const fetch = this.owner.lookup('service:fetch');
+        const results = await controller.searchNavigation({ query: ' live ', limit: 12 });
+
+        assert.deepEqual(fetch.requests, [{ url: 'developers/search', params: { query: 'live', limit: 12 } }], 'calls the developer search endpoint with the trimmed query');
+        assert.deepEqual(results, fetch.response.results, 'returns navigator-ready endpoint results');
+    });
+
+    test('it does not fetch developer resource search results for blank queries', async function (assert) {
+        const controller = this.owner.lookup('controller:application');
+        const fetch = this.owner.lookup('service:fetch');
+        const results = await controller.searchNavigation({ query: '   ', limit: 12 });
+
+        assert.deepEqual(results, []);
+        assert.deepEqual(fetch.requests, [], 'blank queries do not call the adapter');
+    });
+
+    test('it returns empty developer search results when the adapter fails', async function (assert) {
+        const controller = this.owner.lookup('controller:application');
+        const fetch = this.owner.lookup('service:fetch');
+
+        fetch.get = () => Promise.reject(new Error('adapter failed'));
+
+        const results = await controller.searchNavigation({ query: 'live', limit: 12 });
+
+        assert.deepEqual(results, []);
+    });
+});

--- a/translations/ar-ae.yaml
+++ b/translations/ar-ae.yaml
@@ -148,6 +148,39 @@ developers:
       metrics:
         date-created: تاريخ الإنشاء
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: المراقبة
         api-requests: طلبات API

--- a/translations/bg-bg.yaml
+++ b/translations/bg-bg.yaml
@@ -156,6 +156,39 @@ developers:
       metrics:
         date-created: Дата на създаване
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: Мониторинг
         api-requests: API заявки

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -138,6 +138,39 @@ developers:
       metrics:
         date-created: Date Created
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:  
         title: Monitoring
         api-requests: API Requests

--- a/translations/es-es.yaml
+++ b/translations/es-es.yaml
@@ -160,6 +160,39 @@ developers:
       metrics:
         date-created: Fecha de creación
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: Monitorización
         api-requests: Solicitudes API

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -160,6 +160,39 @@ developers:
       metrics:
         date-created: Date de création
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: Surveillance
         api-requests: Requêtes API

--- a/translations/mn-mn.yaml
+++ b/translations/mn-mn.yaml
@@ -152,6 +152,39 @@ developers:
       metrics:
         date-created: Үүсгэсэн огноо
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: Хянах
         api-requests: API Хүсэлтүүд

--- a/translations/pt-br.yaml
+++ b/translations/pt-br.yaml
@@ -155,6 +155,39 @@ developers:
       metrics:
         date-created: Data de Criação
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: Monitoramento
         api-requests: Requisições API

--- a/translations/ru-ru.yaml
+++ b/translations/ru-ru.yaml
@@ -153,6 +153,39 @@ developers:
       metrics:
         date-created: Дата создания
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: Мониторинг
         api-requests: API запросы

--- a/translations/vi-vn.yaml
+++ b/translations/vi-vn.yaml
@@ -152,6 +152,39 @@ developers:
       metrics:
         date-created: Ngày tạo
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: Giám sát
         api-requests: Yêu cầu API

--- a/translations/zh-cn.yaml
+++ b/translations/zh-cn.yaml
@@ -138,6 +138,39 @@ developers:
       metrics:
         date-created: 创建日期
     widget:
+      dashboard:
+        name: Developers Dashboard
+        period: 30d
+        empty: No data available
+        kpi:
+          api-requests: API Requests
+          api-error-rate: API Error Rate
+          api-latency: Avg API Latency
+          webhook-success: Webhook Success
+          active-api-keys: Active API Keys
+          active-webhooks: Active Webhooks
+          webhook-failures: Webhook Failures
+          events-emitted: Events Emitted
+        api-traffic:
+          title: API Traffic
+          subtitle: Request volume, successes, and errors
+        webhook-delivery:
+          title: Webhook Delivery Health
+          subtitle: Delivery volume, retries, and failures
+        endpoint-health:
+          title: Endpoint Health
+          subtitle: Recent webhook endpoint reliability
+        event-stream:
+          title: Event Stream
+          subtitle: Top event types and sources
+          types: Event types
+          sources: Sources
+        developer-activity:
+          title: Developer Activity
+          subtitle: Recent logs, webhooks, and events
+        quick-resources:
+          title: Quick Resources
+          subtitle: Jump into developer tools
       api-metrics:
         title: 监控
         api-requests: API请求


### PR DESCRIPTION
## Summary

- Replace the static developer console home dashboard with the shared Dashboard component using a sticky header.
- Register a dedicated `developers` dashboard with 14 redesigned widgets: 8 KPI tiles and 6 operational/resource widgets.
- Add developer-focused widgets for API traffic, error rate, latency, webhook success, active credentials, active webhook endpoints, endpoint health, event stream, recent activity, and quick resources.
- Add Webhook Failures and Events Emitted KPI tiles so KPI widgets render as two complete rows in the 12-column dashboard grid.
- Normalize default widget sizing so non-KPI widgets render in balanced two-column rows without container overflow.
- Keep the previous API metrics widget available as a legacy widget with `default: false`.
- Add responsive dashboard/widget styling so widget chrome stays fixed, widget content does not overflow, and scrolling is contained inside widget bodies.
- Add integration coverage for the generic KPI tile and quick resources widget.

## Companion PR

This dashboard consumes new internal aggregate metrics endpoints from the companion `core-api` PR:

- https://github.com/fleetbase/core-api/pull/221
- Widgets call the internal `metrics/dev/*` endpoints.

## Validation

- `./node_modules/.bin/eslint . --cache`
- `./node_modules/.bin/ember-template-lint .`
- `./node_modules/.bin/stylelint "**/*.css"`
- `./node_modules/.bin/fleetbase-intl-lint`
- `PATH=/Users/ron/.nvm/versions/node/v22.22.2/bin:$PATH ./node_modules/.bin/ember build --environment=production`
- `./node_modules/.bin/ember build --environment=production` under the default Node 24.6.0 fails during shared CSS minification with `broccoli-persistent-filter:CleanCSSFilter` / `util.isRegExp is not a function`; the same build passes on Node 22.
- `./node_modules/.bin/ember test` was attempted, but the runner fails before app/tests load on an existing vendor runtime error in `ember-engines/components/link-to-external`: `Class extends value [object Object] is not a constructor or null`.

## Documentation and API Reference Impact

- This is a developer console dashboard UI change.
- No public API behavior changes are introduced in this package.
- No `fleetbase/postman` update is required for this PR.
